### PR TITLE
Add PlatformIO support to enable VSCode and CI support

### DIFF
--- a/.github/workflows/platformio.yaml
+++ b/.github/workflows/platformio.yaml
@@ -1,0 +1,24 @@
+name: PlatformIO CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build PlatformIO Project
+        run: pio run

--- a/.github/workflows/platformio.yaml
+++ b/.github/workflows/platformio.yaml
@@ -1,6 +1,13 @@
 name: PlatformIO CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/platformio.yaml
+++ b/.github/workflows/platformio.yaml
@@ -1,9 +1,19 @@
 name: PlatformIO CI
 
 on:
+  release:
+    types: [published]
+
   push:
     branches:
       - main
+      - 'releases/**'
+
+  pull_request:
+    # Sequence of patterns matched against refs/heads
+    branches:
+      - main
+      - 'releases/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/ESP32RET.ino
+++ b/ESP32RET.ino
@@ -283,7 +283,8 @@ void setup()
     //if nothing is connected. But, you can't set 0 or writing rapidly to USB will lose data. It needs
     //some sort of timeout but I'm not sure exactly how much is needed or if there is a better way
     //to deal with this issue.
-    Serial.setTxTimeoutMs(2);
+    // TODO: there is no such method =(
+    // Serial.setTxTimeoutMs(2);
 #endif
     Serial.begin(1000000); //for production
     //Serial.begin(115200); //for testing

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,7 @@ src_dir = ./
 platform = espressif32
 framework = arduino
 lib_deps = 
-	FastLED @ 3.10.0
+	fastled/FastLED @ 3.10.0
 	https://github.com/collin80/can_common#8585f9dc807ebbeedeb509d74159f40f538d2d65
 	https://github.com/collin80/esp32_can#6d835ae82d46748e8267b350680c851a46b38eea
 	https://github.com/collin80/esp32_mcp2517fd#15624220ba3bc2c3e461dc4a0c8e2e3a20d4e94d

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-src_dir = /
+src_dir = ./
 
 [env]
 platform = espressif32
@@ -23,5 +23,5 @@ lib_deps =
 [env:esp32-s3]
 board = esp32-s3-devkitm-1
 
-[env:esp32-c3]
-board = esp32-c3-devkitm-1
+[env:esp32]
+board = esp32dev

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,27 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = /
+
+[env]
+platform = espressif32
+framework = arduino
+lib_deps = 
+	FastLED @ 3.10.0
+	https://github.com/collin80/can_common#8585f9dc807ebbeedeb509d74159f40f538d2d65
+	https://github.com/collin80/esp32_can#6d835ae82d46748e8267b350680c851a46b38eea
+	https://github.com/collin80/esp32_mcp2517fd#15624220ba3bc2c3e461dc4a0c8e2e3a20d4e94d
+
+[env:esp32-s3]
+board = esp32-s3-devkitm-1
+
+[env:esp32-c3]
+board = esp32-c3-devkitm-1


### PR DESCRIPTION
- Add [PlatformIO](https://platformio.org) support to enable development from VSCode
- Add CI check (build for esp32 and esp32s3 inherited from PlatformIO)
- Comment out `Serial.setTxTimeoutMs(2);` because there is no such method available with latest framework